### PR TITLE
Add info helpers

### DIFF
--- a/lib/omniauth/strategies/arise.rb
+++ b/lib/omniauth/strategies/arise.rb
@@ -20,7 +20,10 @@ module OmniAuth
 
 			info do
 			{
-
+				# Note that you'll need to require these info or you'll get nil
+				username: raw_info['get_identifiant'],
+				name:     raw_info['get_nom_complet'],
+				email:    raw_info['get_email'],
 			}
 			end
 
@@ -31,6 +34,10 @@ module OmniAuth
 			end
 
 			def raw_info
+				@raw_info ||= call_api
+			end
+
+			def call_api
 				data = []
 				options.consumer_options.each_with_index do |option, i|
 				data << {


### PR DESCRIPTION
When dealing with integration, one must adapt this strategy. This commit
aims to help this integration by providing some default values in info.
The keys' names have been chosen to somewhat match the GitLab expectations but should be -hopefully- quite spread among other applications.

Note that whether the developer asked for or the user gives these values
is of no importance here, the values will just be nil - which is the
value of a non-existing key in an array.